### PR TITLE
Add `text_content` and `temperature` fields to ideas-ai

### DIFF
--- a/migrations/20250428083315_add_text_content_temperature_to_ideas-ai.js
+++ b/migrations/20250428083315_add_text_content_temperature_to_ideas-ai.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('ideas-ai', table => {
+    table.text('text_content').nullable()
+    table.float('temperature').nullable().defaultTo(0)
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('ideas-ai', table => {
+    table.dropColumn('text_content')
+    table.dropColumn('temperature')
+  })
+}

--- a/src/modules/ai/controllers/portfolio.ts
+++ b/src/modules/ai/controllers/portfolio.ts
@@ -27,6 +27,8 @@ const FIELD_MAPPINGS: Array<{
   transform?: (value: any) => any
 }> = [
   { bodyKey: 'idea', dbKey: 'idea' },
+  { bodyKey: 'text_content', dbKey: 'text_content' },
+  { bodyKey: 'temperature', dbKey: 'temperature' },
   { bodyKey: 'develop_idea_content', dbKey: 'develop_idea_content', transform: toPgArray },
   { bodyKey: 'generated_images', dbKey: 'generated_images', transform: toPgArray },
   { bodyKey: 'model_mvp_content', dbKey: 'model_mvp_content', transform: toPgArray },


### PR DESCRIPTION
Extended the ideas-ai schema with new `text_content` and `temperature` columns to support additional functionality. Updated the portfolio controller to handle these new fields, including mapping them for database operations.